### PR TITLE
Add back empty prompt

### DIFF
--- a/configs/prompt_config.py.example
+++ b/configs/prompt_config.py.example
@@ -64,13 +64,9 @@ PROMPT_TEMPLATES = {
             '<已知信息>{{ context }}</已知信息>\n'
             '<问题>{{ question }}</问题>\n',
 
-        "empty_en":
+        "empty":
             "Please answer my question:\n"
             "{{ question }}\n\n",
-
-        "empty_cn":  # 搜不到知识库的时候使用
-            '请你回答我的问题:\n'
-            '{{ question }}\n\n',
     },
 
 


### PR DESCRIPTION
This can fix the "API通信错误" shown when using `file chat` and `knowledge base QA`, when no related knowledge base files exist

https://github.com/intel-analytics/ipex-llm/issues/10574